### PR TITLE
Fix: print stdout on init

### DIFF
--- a/lib/tfx-cli.js
+++ b/lib/tfx-cli.js
@@ -174,7 +174,7 @@ const cli = function (child, spawn, ...commandArgs) {
       commandArgs[1]
     ).then((data) => {
       // Print init data
-      this.print(data);
+      this.print(data.stdout);
     });
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tfxjs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tfxjs",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfxjs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Terraform acceptance testing framework",
   "main": "./lib/index.js",
   "bin": {

--- a/unit-tests/tfx-cli.test.js
+++ b/unit-tests/tfx-cli.test.js
@@ -46,10 +46,10 @@ const help = [
   `${constants.ansiLtGray}${constants.ansiDefaultForeground}\n`,
   `${constants.ansiLtGray}${constants.ansiDefaultForeground}${constants.ansiLtGray}${constants.ansiBold}To initialize a tfxjs test directory:${constants.ansiResetDim}${constants.ansiDefaultForeground}\n`,
   `${constants.ansiLtGray}${constants.ansiBold}${constants.ansiResetDim}${constants.ansiDefaultForeground}${constants.ansiCyan}  $ tfx init <directory_path>${constants.ansiDefaultForeground}\n`,
-  '\x1B[36m\x1B[39m\x1B[37m\x1B[1m\x1B[22m\x1B[39m\n',
-  '\x1B[37m\x1B[1mTo check the global tfx version:\x1B[22m\x1B[39m\n',
-  '\x1B[37m\x1B[1m\x1B[22m\x1B[39m\x1B[36m  $ tfx version\x1B[39m\n',
-  '\x1B[36m\x1B[39m'
+  "\x1B[36m\x1B[39m\x1B[37m\x1B[1m\x1B[22m\x1B[39m\n",
+  "\x1B[37m\x1B[1mTo check the global tfx version:\x1B[22m\x1B[39m\n",
+  "\x1B[37m\x1B[1m\x1B[22m\x1B[39m\x1B[36m  $ tfx version\x1B[39m\n",
+  "\x1B[36m\x1B[39m",
 ].join("");
 
 let exec = new mockExec({}, false);
@@ -112,7 +112,11 @@ describe("cli", () => {
         actualData = data;
       };
       tfWithLogs.tfxcli();
-      assert.deepEqual(actualData, `tfx cli version 1.1.1`, "it should return correct data");
+      assert.deepEqual(
+        actualData,
+        `tfx cli version 1.1.2`,
+        "it should return correct data"
+      );
     });
     it("should throw error text if bad command", () => {
       let tfWithLogs = new cli(


### PR DESCRIPTION
Fix for `tfx init` command to print stdout directly. Not sure if we need to directly handle stderr here or not.

e.g.
previously
```
{
  stdout: '\n' +
    '> tfxjs generated acceptance tests@0.0.1 build\n' +
    '> npm i && npm i -g tfxjs mocha\n' +
    '\n' +
    '\n' +
    'added 114 packages, and audited 115 packages in 14s\n' +
    '\n' +
    '22 packages are looking for funding\n' +
    '  run `npm fund` for details\n' +
    '\n' +
    'found 0 vulnerabilities\n' +
    '\n' +
    'changed 192 packages, and audited 193 packages in 9s\n' +
    '\n' +
    '23 packages are looking for funding\n' +
    '  run `npm fund` for details\n' +
    '\n' +
    'found 0 vulnerabilities\n',
  stderr: ''
}
```
now
```
> tfxjs generated acceptance tests@0.0.1 build
> npm i && npm i -g tfxjs mocha


added 114 packages, and audited 115 packages in 10s

22 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

changed 192 packages, and audited 193 packages in 9s

23 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```